### PR TITLE
add __bool__ for an FSM

### DIFF
--- a/interegular/fsm.py
+++ b/interegular/fsm.py
@@ -761,6 +761,15 @@ class FSM:
 
         return get_num_strings(self.initial)
 
+    def __bool__(self):
+        """
+            Check if the FSM accepts at least one string (i.e. is not empty). This
+            is better than checking len(.), which is computationally more expensive,
+            and will raise an OverflowError in case there are an infinite amount of
+            strings, whereas bool(.) will just return True.
+        """
+        return not self.empty()
+
     def __len__(self):
         """
             Consider the FSM as a set of strings and return the cardinality of that


### PR DESCRIPTION
Currently when using `if my_fsm`, it will fallback on `__len__` which will raise an `OverflowError` in case there are an infinite many strings that match the FSM.

We can just check if the FSM is empty. This is "equivalent" with the current implementation in the sense that for FSMs that accept a finite number of strings, the `bool` will be the same for both versions, but by adding a `__bool__` we will also return `True` if an infinite amount of strings are accepted, and it is less computationally expensive.